### PR TITLE
Changed token creation to URL - Encoded

### DIFF
--- a/internal/woffuapi/token.go
+++ b/internal/woffuapi/token.go
@@ -22,15 +22,16 @@ func (w WoffuAPI) CreateToken() (*TokenResponse, error) {
 	credentials := strings.Split(w.auth.Credentials(), ":")
 
 	// Build API Request
+	body := fmt.Sprintf("grant_type=password&username=%s&password=%s", credentials[0], credentials[1])
 	apiRequest := APIRequest{
 		method:   "POST",
 		endpoint: "/token",
 		headers: map[string]string{
 			"Accept":       "application/json",
-			"Content-Type": "application/json",
+			"Content-Type": "application/x-www-form-urlencoded",
 		},
 		// Credentials need to be passed in the body :S
-		body: []byte(fmt.Sprintf("grant_type=password&username=%s&password=%s", credentials[0], credentials[1])),
+		body: []byte(body),
 	}
 
 	// Get Token


### PR DESCRIPTION
For some reason, when trying to create a new token it resulted in an error:

goroutine 1 [running]:
log.Panic({0x1400014fcf0?, 0x0?, 0x0?})
	/home/migue/.asdf/installs/golang/1.20.5/go/src/log/log.go:384 +0x64
github.com/Madh93/toffu/cmd.glob..func5(0x1013e7c80?, {0x10100d264?, 0x0?, 0x0?})
	/home/migue/Workspace/repos/toffu/cmd/token.go:17 +0x5c
github.com/spf13/cobra.(*Command).execute(0x1013e7c80, {0x1014257e8, 0x0, 0x0})
	/home/migue/.go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:944 +0x5b0
github.com/spf13/cobra.(*Command).ExecuteC(0x1013e76c0)
	/home/migue/.go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:1068 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	/home/migue/.go/pkg/mod/github.com/spf13/cobra@v1.7.0/command.go:992
github.com/Madh93/toffu/cmd.Execute(...)
	/home/migue/Workspace/repos/toffu/cmd/root.go:31
main.main()
	/home/migue/Workspace/repos/toffu/main.go:11 +0x40
	
And when digging into it, it was a result of the petition always getting status code 403: Forbidden.

For some reason, simply changing content type from application/json to url-encoded fixed the problem.